### PR TITLE
Use aws-vault login code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ This is a tool used to log into AWS accounts using 1Password MFA tokens.
 
 Before using this tool you must install these prerequisites:
 
-- [1Password Command Line Tool](https://support.1password.com/command-line-getting-started/)
-- [aws-vault](https://github.com/99designs/aws-vault)
-- A web browser such as Chrome, Safari, or Firefox
+* [1Password Command Line Tool](https://support.1password.com/command-line-getting-started/) @ version 1.11.4 or later
+* [aws-vault](https://github.com/99designs/aws-vault) @ version v6.3.1 or later
+
+Supported web browsers include:
+
+* Chrome
+* Chrome Canary
+* Safari
+* Firefox
 
 You must then sign into 1Password at least once using the `op` command. Also include a `--shorthand` for future use.
 

--- a/cmd/awslogin/login.go
+++ b/cmd/awslogin/login.go
@@ -40,8 +40,7 @@ const (
 	browserSafari          = "safari"
 	browserFirefox         = "firefox"
 
-	minVersionOP       = "1.11.4"
-	minVersionAWSVault = "v6.3.1"
+	minVersionOP = "1.11.4"
 )
 
 var (
@@ -141,10 +140,6 @@ func login(cmd *cobra.Command, args []string) error {
 
 	// Confirm that the minimum version is met for these tools
 	errPreCheck := preCheck("/usr/local/bin/op", []string{"--version"}, minVersionOP)
-	if errPreCheck != nil {
-		return errPreCheck
-	}
-	errPreCheck = preCheck("/usr/local/bin/aws-vault", []string{"--version"}, minVersionAWSVault)
 	if errPreCheck != nil {
 		return errPreCheck
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.17
 
 require (
 	github.com/99designs/aws-vault/v6 v6.3.1
+	github.com/99designs/keyring v1.1.6
+	github.com/aws/aws-sdk-go v1.40.34
 	github.com/goreleaser/goreleaser v0.179.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
@@ -18,7 +20,6 @@ require (
 	cloud.google.com/go/kms v0.1.0 // indirect
 	cloud.google.com/go/storage v1.16.1 // indirect
 	code.gitea.io/sdk/gitea v0.15.0 // indirect
-	github.com/99designs/keyring v1.1.6 // indirect
 	github.com/AlekSi/pointer v1.1.0 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
 	github.com/Azure/azure-sdk-for-go v57.0.0+incompatible // indirect
@@ -47,7 +48,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 // indirect
 	github.com/apex/log v1.9.0 // indirect
 	github.com/atc0005/go-teams-notify/v2 v2.6.0 // indirect
-	github.com/aws/aws-sdk-go v1.40.34 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.9.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.7.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.4.0 // indirect

--- a/pkg/awsvault/list.go
+++ b/pkg/awsvault/list.go
@@ -1,44 +1,19 @@
 package awsvault
 
 import (
-	"io/ioutil"
-	"log"
 	"time"
 
-	"github.com/99designs/aws-vault/v6/cli"
 	"github.com/99designs/aws-vault/v6/vault"
+	"github.com/99designs/keyring"
 )
 
-func GetProfiles() ([]string, error) {
-	// Disable the logging from the vault package
-	log.SetOutput(ioutil.Discard)
+func GetProfiles(f *vault.ConfigFile) ([]string, error) {
 
-	awsVault := &cli.AwsVault{}
-
-	awsConfigFile, err := awsVault.AwsConfigFile()
-	if err != nil {
-		return []string{}, err
-	}
-
-	return awsConfigFile.ProfileNames(), nil
+	return f.ProfileNames(), nil
 }
 
-func GetSessions() (map[string]time.Duration, error) {
-	// Disable the logging from the vault package
-	log.SetOutput(ioutil.Discard)
-
+func GetSessions(f *vault.ConfigFile, keyring keyring.Keyring) (map[string]time.Duration, error) {
 	profileSessions := map[string]time.Duration{}
-
-	awsVault := &cli.AwsVault{}
-	keyring, err := awsVault.Keyring()
-	if err != nil {
-		return profileSessions, err
-	}
-
-	awsConfigFile, err := awsVault.AwsConfigFile()
-	if err != nil {
-		return profileSessions, err
-	}
 
 	credentialKeyring := &vault.CredentialKeyring{Keyring: keyring}
 	sessionKeyring := &vault.SessionKeyring{Keyring: credentialKeyring.Keyring}
@@ -48,7 +23,7 @@ func GetSessions() (map[string]time.Duration, error) {
 		return profileSessions, err
 	}
 
-	for _, profileName := range awsConfigFile.ProfileNames() {
+	for _, profileName := range f.ProfileNames() {
 
 		// check session keyring
 		for _, sess := range sessions {

--- a/pkg/awsvault/login.go
+++ b/pkg/awsvault/login.go
@@ -1,0 +1,141 @@
+package awsvault
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/99designs/aws-vault/v6/vault"
+	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+func generateLoginURL(region string, path string) (string, string) {
+	loginURLPrefix := "https://signin.aws.amazon.com/federation"
+	destination := "https://console.aws.amazon.com/"
+
+	if region != "" {
+		destinationDomain := "console.aws.amazon.com"
+		switch {
+		case strings.HasPrefix(region, "cn-"):
+			loginURLPrefix = "https://signin.amazonaws.cn/federation"
+			destinationDomain = "console.amazonaws.cn"
+		case strings.HasPrefix(region, "us-gov-"):
+			loginURLPrefix = "https://signin.amazonaws-us-gov.com/federation"
+			destinationDomain = "console.amazonaws-us-gov.com"
+		}
+		if path != "" {
+			destination = fmt.Sprintf("https://%s.%s/%s?region=%s",
+				region, destinationDomain, path, region)
+		} else {
+			destination = fmt.Sprintf("https://%s.%s/console/home?region=%s",
+				region, destinationDomain, region)
+		}
+	}
+	return loginURLPrefix, destination
+}
+
+func GetLoginURL(profileName string, mfaToken string, f *vault.ConfigFile, keyring keyring.Keyring) (*string, error) {
+	vault.UseSession = true
+
+	sessionDuration, errParseDuration := time.ParseDuration("1h")
+	if errParseDuration != nil {
+		return nil, errParseDuration
+	}
+	configLoader := vault.ConfigLoader{
+		File: f,
+		BaseConfig: vault.Config{
+			MfaToken:                          mfaToken,
+			MfaPromptMethod:                   "terminal",
+			NonChainedGetSessionTokenDuration: sessionDuration,
+			AssumeRoleDuration:                sessionDuration,
+			GetFederationTokenDuration:        sessionDuration,
+		},
+		ActiveProfile: profileName,
+	}
+	config, err := configLoader.LoadFromProfile(profileName)
+	if err != nil {
+		return nil, fmt.Errorf("Error loading config: %w", err)
+	}
+
+	var creds *credentials.Credentials
+
+	ckr := &vault.CredentialKeyring{Keyring: keyring}
+	// If AssumeRole or sso.GetRoleCredentials isn't used, GetFederationToken has to be used for IAM credentials
+	if config.HasRole() || config.HasSSOStartURL() {
+		creds, err = vault.NewTempCredentials(config, ckr)
+	} else {
+		creds, err = vault.NewFederationTokenCredentials(profileName, ckr, config)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("profile %s: %w", profileName, err)
+	}
+
+	val, err := creds.Get()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get credentials for %s: %w", config.ProfileName, err)
+	}
+
+	jsonBytes, err := json.Marshal(map[string]string{
+		"sessionId":    val.AccessKeyID,
+		"sessionKey":   val.SecretAccessKey,
+		"sessionToken": val.SessionToken,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	loginURLPrefix, destination := generateLoginURL(config.Region, "")
+
+	req, err := http.NewRequest("GET", loginURLPrefix, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if expiration, errExpiresAt := creds.ExpiresAt(); errExpiresAt != nil {
+		log.Printf("Creating login token, expires in %s", time.Until(expiration))
+	}
+
+	q := req.URL.Query()
+	q.Add("Action", "getSigninToken")
+	q.Add("Session", string(jsonBytes))
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("Response body was %s", body)
+		return nil, fmt.Errorf("Call to getSigninToken failed with %v", resp.Status)
+	}
+
+	var respParsed map[string]string
+
+	err = json.Unmarshal([]byte(body), &respParsed)
+	if err != nil {
+		return nil, err
+	}
+
+	signinToken, ok := respParsed["SigninToken"]
+	if !ok {
+		return nil, fmt.Errorf("Expected a response with SigninToken")
+	}
+
+	loginURL := fmt.Sprintf("%s?Action=login&Issuer=aws-vault&Destination=%s&SigninToken=%s",
+		loginURLPrefix, url.QueryEscape(destination), url.QueryEscape(signinToken))
+
+	return &loginURL, nil
+}

--- a/pkg/op/signin.go
+++ b/pkg/op/signin.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"golang.org/x/term"
+	"github.com/99designs/aws-vault/v6/prompt"
 )
 
 func Signin(sessionFilename string) (*Config, error) {
@@ -17,12 +17,10 @@ func Signin(sessionFilename string) (*Config, error) {
 		return nil, errGetExecPath
 	}
 
-	fmt.Println("Enter your 1Password password:")
-	bytePassword, errReadPassword := term.ReadPassword(0)
-	if errReadPassword != nil {
-		log.Fatal(errReadPassword)
+	pass, errTerminalSecretPrompt := prompt.TerminalSecretPrompt("Enter your 1Password password: ")
+	if errTerminalSecretPrompt != nil {
+		return nil, errTerminalSecretPrompt
 	}
-	pass := strings.TrimSpace(string(bytePassword))
 
 	command := exec.Command(*opPath, "signin")
 	stdin, errStdinPipe := command.StdinPipe()


### PR DESCRIPTION
Instead of shelling out to aws-vault the code now uses the aws-vault golang sdk. This means folks don't need aws-vault installed on the system to get the login URL.