### PR TITLE
Fix the filters to not include an empty string

### DIFF
--- a/cmd/awslogin/login.go
+++ b/cmd/awslogin/login.go
@@ -276,7 +276,7 @@ func chooseAccountAlias(config *op.Config, sectionName, fieldTitle string, filte
 		for _, item := range items {
 			for _, f := range filters {
 				title := item.Overview.Title
-				if strings.Contains(title, f) {
+				if len(f) > 0 && strings.Contains(title, f) {
 					newItemList = append(newItemList, item)
 				}
 			}

--- a/cmd/awslogin/login.go
+++ b/cmd/awslogin/login.go
@@ -153,9 +153,12 @@ func login(cmd *cobra.Command, args []string) error {
 	var filters []string
 	if len(args) > 0 {
 		// When using filters the AWS_PROFILE should be added to the list
-		filters = append(args, accountAlias)
-		// The accountAlias is set to an empty string to ensure that the filters are used
-		accountAlias = ""
+		filters = args
+		if len(accountAlias) > 0 {
+			filters = append(filters, accountAlias)
+			// The accountAlias is set to an empty string to ensure that the filters are used
+			accountAlias = ""
+		}
 	}
 
 	// Handle Flags


### PR DESCRIPTION
A code change I made added an empty string to the filters list which was then used in picking accounts, so that just listed everything.