### PR TITLE
Make env vars unique and document them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ The browser to use can also be changed if desired:
 go run github.com/deptofdefense/awslogin/cmd/awslogin alias-example --browser firefox
 ```
 
+### Environment Variables
+
+It's possible to set environment variables globally in your environment to change the behavior of the tool. Here is a list
+of the available env vars:
+
+| Env Var | Default | Choices | Description |
+| --- | --- | --- | --- |
+| AWSLOGIN_BROWSER | `chrome` | `chrome`, `chrome-canary`, `safari`, `firefox` | The browser to open the Login URL |
+| AWSLOGIN_FIELD_TITLE | `ACCOUNT_ALIAS` | N/A | The 1Password section name used to identify AWS Account Info |
+| AWSLOGIN_SECTION_NAME | `ACCOUNT_INFO` | N/A | The 1Password field title used to identify AWS Account Alias |
+| AWSLOGIN_SESSION_DIRECTORY | `$HOME` | N/A | The path of the directory to hold the session information |
+| AWSLOGIN_SESSION_FILENAME | `.op_session` | N/A | The name of the file to retain session information |
+| AWSLOGIN_VERBOSE | false | Boolean | Use verbose output |
+| AWSLOGIN_VERSION | false | Boolean | Display the version information and exit |
+
 ### AWS Profile Env Var
 
 In the case where you are using a system to manage environment variables (like [direnv](https://direnv.net)) you may

--- a/cmd/awslogin/login.go
+++ b/cmd/awslogin/login.go
@@ -26,14 +26,13 @@ import (
 )
 
 const (
-	flagLoginBrowser     = "browser"
-	flagLoginSectionName = "section-name"
-	flagLoginFieldTitle  = "field-title"
-	flagLoginVersion     = "version"
-	flagLoginVerbose     = "verbose"
-
-	flagSessionDirectory = "session-directory"
-	flagSessionFilename  = "session-filename"
+	flagLoginBrowser          = "browser"
+	flagLoginFieldTitle       = "field-title"
+	flagLoginSectionName      = "section-name"
+	flagLoginSessionDirectory = "session-directory"
+	flagLoginSessionFilename  = "session-filename"
+	flagLoginVerbose          = "verbose"
+	flagLoginVersion          = "version"
 
 	browserChrome          = "chrome"
 	browserChromeIncognito = "chrome-incognito"
@@ -60,11 +59,11 @@ var (
 )
 
 func initLoginFlags(flag *pflag.FlagSet) {
-	flag.String(flagLoginBrowser, browserChrome, "The browser to open with")
-	flag.String(flagLoginSectionName, "ACCOUNT_INFO", "The 1Password section name used to identify AWS credentials")
+	flag.String(flagLoginBrowser, browserChrome, "The browser to open the Login URL")
+	flag.String(flagLoginSectionName, "ACCOUNT_INFO", "The 1Password section name used to identify AWS Account Info")
 	flag.String(flagLoginFieldTitle, "ACCOUNT_ALIAS", "The 1Password field title used to identify AWS Account Alias")
-	flag.String(flagSessionDirectory, HOMEDIR, "The path of the directory to hold the session information")
-	flag.String(flagSessionFilename, SESSION_FILE, "The name of the file to retain session information")
+	flag.String(flagLoginSessionDirectory, HOMEDIR, "The path of the directory to hold the session information")
+	flag.String(flagLoginSessionFilename, SESSION_FILE, "The name of the file to retain session information")
 	flag.Bool(flagLoginVersion, false, "Display the version information and exit")
 	flag.Bool(flagLoginVerbose, false, "Use verbose output")
 }
@@ -74,7 +73,7 @@ func checkLoginConfig(v *viper.Viper) error {
 	if _, ok := browserToPath[browser]; !ok {
 		return fmt.Errorf("Given browser %q is not an option\n", browser)
 	}
-	sessionDirectory := v.GetString(flagSessionDirectory)
+	sessionDirectory := v.GetString(flagLoginSessionDirectory)
 	if sessionDirectory == HOMEDIR {
 		homedir, errUserHomeDir := os.UserHomeDir()
 		if errUserHomeDir != nil {
@@ -85,7 +84,7 @@ func checkLoginConfig(v *viper.Viper) error {
 	if _, err := os.Stat(sessionDirectory); os.IsNotExist(err) {
 		return fmt.Errorf("The session directory %q does not exist\n", sessionDirectory)
 	}
-	sessionFilename := v.GetString(flagSessionFilename)
+	sessionFilename := v.GetString(flagLoginSessionFilename)
 	if len(sessionFilename) == 0 {
 		return errors.New("The session filename should not be empty")
 	}
@@ -166,8 +165,8 @@ func login(cmd *cobra.Command, args []string) error {
 	browserPath := browserToPath[browser]
 	sectionName := v.GetString(flagLoginSectionName)
 	fieldTitle := v.GetString(flagLoginFieldTitle)
-	sessionDirectory := v.GetString(flagSessionDirectory)
-	sessionFilename := v.GetString(flagSessionFilename)
+	sessionDirectory := v.GetString(flagLoginSessionDirectory)
+	sessionFilename := v.GetString(flagLoginSessionFilename)
 	verbose := v.GetBool(flagLoginVerbose)
 
 	// Get the session path for using 1Password

--- a/cmd/awslogin/main.go
+++ b/cmd/awslogin/main.go
@@ -21,6 +21,7 @@ func initViper(cmd *cobra.Command) (*viper.Viper, error) {
 	if errBind != nil {
 		return v, fmt.Errorf("error binding flag set to viper: %w\n", errBind)
 	}
+	v.SetEnvPrefix(CLI_NAME) // Enforces all env vars to require "AWSLOGIN_", making them unique
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv() // set environment variables to overwrite config
 	return v, nil


### PR DESCRIPTION
The major change is to require `AWSLOGIN_` as a prefix for the env vars.